### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete string escaping or encoding

### DIFF
--- a/themes/hugo-vitae/static/js/katex.js
+++ b/themes/hugo-vitae/static/js/katex.js
@@ -10708,7 +10708,7 @@ defineEnvironment({
       "Bmatrix": ["\\{", "\\}"],
       "vmatrix": ["|", "|"],
       "Vmatrix": ["\\Vert", "\\Vert"]
-    }[context.envName.replace("*", "")]; // \hskip -\arraycolsep in amsmath
+    }[context.envName.replace(/\*/g, "")]; // \hskip -\arraycolsep in amsmath
 
     var colAlign = "c";
     var payload = {


### PR DESCRIPTION
Potential fix for [https://github.com/alc-beijing/alc-site/security/code-scanning/3](https://github.com/alc-beijing/alc-site/security/code-scanning/3)

To fix the problem, we should ensure that all occurrences of the asterisk character (`*`) are removed from `context.envName`, not just the first one. This can be done by replacing the string argument in `.replace("*", "")` with a regular expression `/\*/g`, which will match all asterisks globally. The change should be made directly on line 10711 in the file `themes/hugo-vitae/static/js/katex.js`. No additional imports or definitions are needed, as this is standard JavaScript functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
