### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete string escaping or encoding

### DIFF
--- a/themes/hugo-vitae/static/js/katex.js
+++ b/themes/hugo-vitae/static/js/katex.js
@@ -11532,7 +11532,7 @@ var genfrac_mathmlBuilder = function mathmlBuilder(group, options) {
     var withDelims = [];
 
     if (group.leftDelim != null) {
-      var leftOp = new mathMLTree.MathNode("mo", [new mathMLTree.TextNode(group.leftDelim.replace("\\", ""))]);
+      var leftOp = new mathMLTree.MathNode("mo", [new mathMLTree.TextNode(group.leftDelim.replace(/\\/g, ""))]);
       leftOp.setAttribute("fence", "true");
       withDelims.push(leftOp);
     }
@@ -11540,7 +11540,7 @@ var genfrac_mathmlBuilder = function mathmlBuilder(group, options) {
     withDelims.push(node);
 
     if (group.rightDelim != null) {
-      var rightOp = new mathMLTree.MathNode("mo", [new mathMLTree.TextNode(group.rightDelim.replace("\\", ""))]);
+      var rightOp = new mathMLTree.MathNode("mo", [new mathMLTree.TextNode(group.rightDelim.replace(/\\/g, ""))]);
       rightOp.setAttribute("fence", "true");
       withDelims.push(rightOp);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/alc-beijing/alc-site/security/code-scanning/4](https://github.com/alc-beijing/alc-site/security/code-scanning/4)

To fix the problem, we should ensure that all occurrences of the backslash character are removed from the delimiter string. In JavaScript, this is best done by using a regular expression with the global flag: `replace(/\\/g, "")`. This will replace all backslashes in the string, not just the first. The fix should be applied to both `group.leftDelim.replace("\\", "")` and `group.rightDelim.replace("\\", "")` (lines 11535 and 11543, respectively), as they both use the same pattern. No new imports or dependencies are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
